### PR TITLE
strips comments from hxml parsing

### DIFF
--- a/src/Main.hx
+++ b/src/Main.hx
@@ -532,6 +532,12 @@ class Main {
 		var lines = sys.io.File.read(f, false).readAll().toString().split(NEW_LINE);
 		var i = 0;
 		while( i<lines.length ) {
+
+			// trims the comment content from the line.
+			var commentHash = lines[i].indexOf("#");
+			if( commentHash >= 0 )
+				lines[i] = lines[i].substr(0, commentHash);
+
 			if( lines[i].indexOf(".hxml")>=0 && lines[i].indexOf("-cmd")<0 )
 				lines[i] = getFullHxml(lines[i]);
 			i++;


### PR DESCRIPTION
I took a stab at it.

Testing some comments, it looks like **redistHelper** will essentially ignore comments because it doesn't know what to do with them.

In my case I was titling my files with the file name, and it was attempting to load those files and import those `.hxml` libraries, but they couldn't be accessed since the path wasn't included.

Opted for trimming the line right at the parser in order to remove that comment line, so works for both leading comments, and comments somewhere else on the line.