### PR TITLE
Fix build error on linux

### DIFF
--- a/src/Main.hx
+++ b/src/Main.hx
@@ -529,19 +529,25 @@ class Main {
 		var exes = [];
 		for( r in runTimeFiles.files ) {
 			if( r.lib==null || hxmlRequiresLib(hxmlPath, r.lib) ) {
-				var fileName = useHl32bits && r.f32!=null ? r.f32 : r.f;
-				var from = findFile(fileName, useHl32bits);
-				if( verbose )
-					Lib.println(" -> "+fileName + ( r.lib==null?"" : " [required by -lib "+r.lib+"] (source: "+from+")") );
-				var toFile = r.executableFormat!=null ? StringTools.replace(r.executableFormat, "$", projectName) : fileName.indexOf("/")<0 ? fileName : fileName.substr(fileName.lastIndexOf("/")+1);
-				var to = targetDir+"/"+toFile;
-				if( r.executableFormat!=null && verbose )
-					Lib.println(" -> Renamed executable to "+toFile);
-				copy(from, to);
+				try {
+					var fileName = useHl32bits && r.f32!=null ? r.f32 : r.f;
+					var from = findFile(fileName, useHl32bits);
 
-				// List executables
-				if( r.executableFormat!=null )
-					exes.push( FilePath.fromFile(targetDir+"/"+toFile) );
+					if( verbose )
+						Lib.println(" -> "+fileName + ( r.lib==null?"" : " [required by -lib "+r.lib+"] (source: "+from+")") );
+					var toFile = r.executableFormat!=null ? StringTools.replace(r.executableFormat, "$", projectName) : fileName.indexOf("/")<0 ? fileName : fileName.substr(fileName.lastIndexOf("/")+1);
+					var to = targetDir+"/"+toFile;
+					if( r.executableFormat!=null && verbose )
+						Lib.println(" -> Renamed executable to "+toFile);
+					copy(from, to);
+	
+					// List executables
+					if( r.executableFormat!=null )
+						exes.push( FilePath.fromFile(targetDir+"/"+toFile) );
+				} catch (e) {
+					Lib.println(e.message);
+				}
+
 			}
 		}
 


### PR DESCRIPTION
When running the script on Linux, it would fail to create a build. This was because it would throw an unhandled exception when looking for the hl.exe file. The exception is now caught, so the script can not proceed to actually creating the Linux build.